### PR TITLE
feat: add custom exceptions

### DIFF
--- a/src/main/java/com/extendablechattingbe/extendablechattingbe/error/exception/BadRequestException.java
+++ b/src/main/java/com/extendablechattingbe/extendablechattingbe/error/exception/BadRequestException.java
@@ -1,0 +1,14 @@
+package com.extendablechattingbe.extendablechattingbe.error.exception;
+
+import static org.springframework.http.HttpStatus.*;
+
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import com.extendablechattingbe.extendablechattingbe.error.ErrorCode;
+
+@ResponseStatus(BAD_REQUEST)
+public class BadRequestException extends ApiException {
+	public BadRequestException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/com/extendablechattingbe/extendablechattingbe/error/exception/ConflictException.java
+++ b/src/main/java/com/extendablechattingbe/extendablechattingbe/error/exception/ConflictException.java
@@ -1,0 +1,14 @@
+package com.extendablechattingbe.extendablechattingbe.error.exception;
+
+import static org.springframework.http.HttpStatus.*;
+
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import com.extendablechattingbe.extendablechattingbe.error.ErrorCode;
+
+@ResponseStatus(CONFLICT)
+public class ConflictException extends ApiException {
+	public ConflictException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/com/extendablechattingbe/extendablechattingbe/error/exception/ForbiddenException.java
+++ b/src/main/java/com/extendablechattingbe/extendablechattingbe/error/exception/ForbiddenException.java
@@ -1,0 +1,14 @@
+package com.extendablechattingbe.extendablechattingbe.error.exception;
+
+import static org.springframework.http.HttpStatus.*;
+
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import com.extendablechattingbe.extendablechattingbe.error.ErrorCode;
+
+@ResponseStatus(FORBIDDEN)
+public class ForbiddenException extends ApiException {
+	public ForbiddenException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/com/extendablechattingbe/extendablechattingbe/error/exception/NotFoundException.java
+++ b/src/main/java/com/extendablechattingbe/extendablechattingbe/error/exception/NotFoundException.java
@@ -1,0 +1,14 @@
+package com.extendablechattingbe.extendablechattingbe.error.exception;
+
+import static org.springframework.http.HttpStatus.*;
+
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import com.extendablechattingbe.extendablechattingbe.error.ErrorCode;
+
+@ResponseStatus(NOT_FOUND)
+public class NotFoundException extends ApiException {
+	public NotFoundException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/com/extendablechattingbe/extendablechattingbe/error/exception/RoomNotFoundException.java
+++ b/src/main/java/com/extendablechattingbe/extendablechattingbe/error/exception/RoomNotFoundException.java
@@ -1,9 +1,0 @@
-package com.extendablechattingbe.extendablechattingbe.error.exception;
-
-import com.extendablechattingbe.extendablechattingbe.error.ErrorCode;
-
-public class RoomNotFoundException extends ApiException {
-	public RoomNotFoundException(ErrorCode errorCode) {
-		super(errorCode);
-	}
-}

--- a/src/main/java/com/extendablechattingbe/extendablechattingbe/error/exception/UnauthorizedException.java
+++ b/src/main/java/com/extendablechattingbe/extendablechattingbe/error/exception/UnauthorizedException.java
@@ -1,0 +1,14 @@
+package com.extendablechattingbe.extendablechattingbe.error.exception;
+
+import static org.springframework.http.HttpStatus.*;
+
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import com.extendablechattingbe.extendablechattingbe.error.ErrorCode;
+
+@ResponseStatus(UNAUTHORIZED)
+public class UnauthorizedException extends ApiException {
+	public UnauthorizedException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}


### PR DESCRIPTION
## 코드 설명
- `@ResponseStatus()`은 사용자 지정 상태 코드 반환 어노테이션입니다.
  - enum errorCode 에서 상태값을 전달해서 삭제해도 되긴 하는데, 코드 가시성을 위해서 추가해보았습니다.

## 사용 방법
**예) 방을 삭제하는 로직에서 방을 찾을 수 없는 경우**

1. **enum ErrorCode** 에 내가 만들고 싶은 에러 추가 - `ROOM_NOT_FOUND_ERROR`

```java
@Getter
@AllArgsConstructor
public enum ErrorCode {

	// Global
	INTERNAL_SERVER_ERROR(500, HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류입니다."),
  ...

	// Room
  ROOM_NOT_FOUND_ERROR(404, HttpStatus.NOT_FOUND, "해당 방이 존재하지 않습니다.")
  ...

	;

	private final int value;
	private final HttpStatus status;
	private final String message;

}
```
2. 로직에서 **사용**

```java
@Service
@Transactional(readOnly = true)
@RequiredArgsConstructor
public class RoomService {

    public void delete(Long id){
        Room deleteRoom = repository.findById(id)
			    .orElseThrow(() -> new NotFoundException(ErrorCode.ROOM_NOT_FOUND_ERROR));  
        repository.delete(deleteRoom);
    }
}
```