### PR TITLE
!HOTFIX: deploy.yml의 ubuntu version 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   deploy:
     name: Deploy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: production
 
     steps:


### PR DESCRIPTION
## 상황
Github Actions 을 통한 자동 배포에서 에러 발생하였습니다. - `deploy.yml` 파일

## 원인
알고보니 우분투 버전을 항상 최신 버전으로 지정해놓았던 것이 원인이었습니다. 우분투 버전이 업그레이드 되면서 aws-cli 명령어가 바뀐부분이 생겼고, 일부 명령어들이 작동하지 않아서 발생하는 에러로 보입니다.

## 해결
ubuntu-22.04 로 버전을 지정하여 해결하였습니다.
```jobs:
  deploy:
    name: Deploy
    runs-on: ubuntu-22.04
    environment: production
```